### PR TITLE
better OS/backwards compatibility for path.sep

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ var path = require('path');
 
 var Magic = require('./build/Release/magic');
 
-Magic.setFallback(__dirname + path.sep + 'magic' + path.sep + 'magic');
+var sep = path.sep || path.SPLIT_CHAR;
+
+Magic.setFallback(__dirname + sep + 'magic' + sep + 'magic');
 
 module.exports = {
   Magic: Magic.Magic,


### PR DESCRIPTION
On OS X 10.6 and 10.7, running node 0.6.19, if I do this:

``` javascript
var path = require('path');
console.log(path);
console.log("Sep: %s", path.sep);
console.log("Sep2: %s", path.SPLIT_CHAR);
```

I get this:

```
{ resolve: [Function],
  normalize: [Function],
  join: [Function],
  relative: [Function],
  dirname: [Function],
  basename: [Function],
  extname: [Function],
  exists: [Function],
  existsSync: [Function],
  _makeLong: [Function],
  SPLIT_CHAR: '/' }
Sep: undefined
Sep2: /
```

So it appears that at least in some instances, path.sep is not available. This patch adjusts the Magic.setFallback() setup in index.js to be more resilient for this case.
