### PR TITLE
get rid of compiler warnings

### DIFF
--- a/deps/libmagic/config/freebsd/config.h
+++ b/deps/libmagic/config/freebsd/config.h
@@ -90,9 +90,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #define HAVE_MMAP 1
 
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/config/linux/config.h
+++ b/deps/libmagic/config/linux/config.h
@@ -90,9 +90,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #define HAVE_MMAP 1
 
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/config/mac/config.h
+++ b/deps/libmagic/config/mac/config.h
@@ -90,9 +90,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #define HAVE_MMAP 1
 
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/config/openbsd/config.h
+++ b/deps/libmagic/config/openbsd/config.h
@@ -90,9 +90,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #define HAVE_MMAP 1
 
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/config/sunos/config.h
+++ b/deps/libmagic/config/sunos/config.h
@@ -87,9 +87,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #define HAVE_MMAP 1
 
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/config/win/config.h
+++ b/deps/libmagic/config/win/config.h
@@ -90,9 +90,6 @@
 /* Define to 1 if you have a working `mmap' system call. */
 #undef HAVE_MMAP
 
-/* Define to 1 if you have the `pread' function. */
-#undef HAVE_PREAD
-
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1
 

--- a/deps/libmagic/pcre/pcre_compile.c
+++ b/deps/libmagic/pcre/pcre_compile.c
@@ -3462,7 +3462,7 @@ if ((options & PCRE_CASELESS) != 0)
   if ((options & PCRE_UTF8) != 0)
     {
     int rc;
-    pcre_uint32 oc, od;
+    pcre_uint32 oc, od = 0;
 
     options &= ~PCRE_CASELESS;   /* Remove for recursive calls */
     c = start;

--- a/deps/libmagic/src/cdf.c
+++ b/deps/libmagic/src/cdf.c
@@ -43,7 +43,6 @@ FILE_RCSID("@(#)$File: cdf.c,v 1.55 2014/02/27 23:26:17 christos Exp $")
 #include <err.h>
 #endif
 #include <stdlib.h>
-//#include <unistd.h>
 #include <string.h>
 #include <time.h>
 #include <ctype.h>

--- a/deps/libmagic/src/file.h
+++ b/deps/libmagic/src/file.h
@@ -518,9 +518,8 @@ extern char *sys_errlist[];
 #define strtoul(a, b, c)	strtol(a, b, c)
 #endif
 
-#ifndef HAVE_PREAD
 ssize_t pread(int, void *, size_t, off_t);
-#endif
+
 #ifndef HAVE_VASPRINTF
 int vasprintf(char **, const char *, va_list);
 #endif


### PR DESCRIPTION
I get the following compilation warnings.

```
../deps/libmagic/src/cdf.c: In function ‘cdf_read’:
../deps/libmagic/src/cdf.c:299:2: warning: implicit declaration of function ‘pread’ [-Wimplicit-function-declaration]
```

I'm assuming the first one is related to adding support for windows. All *nix architectures that define `HAVE_PREAD` should get this warning because `<unistd.h>` no longer is included. And windows doesn't get this warning because `HAVE_PREAD` is undefined. The solution is to remove the `HAVE_PREAD` constant altogether and simply use the same function signature for all architectures.

Please correct me if I'm wrong and have missed something here.

```
../deps/libmagic/pcre/pcre_compile.c: In function ‘add_to_class’:
../deps/libmagic/pcre/pcre_compile.c:3487:30: warning: ‘od’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```

This warning is related to `od` not being initialized _if_ `get_othercase_range()` returns from: https://github.com/mscdex/mmmagic/blob/master/deps/libmagic/pcre/pcre_compile.c#L2935-L2937, but since `get_othercase_range()` returns a non zero value the value of `od` is irrelevant, hence we can just set the initial value of `od` to anything, e.g. 0.

Unfortunately there aren't any tests I can run to make sure this is completely ok, so need your feedback.
