### PR TITLE
Updating nan to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An async libmagic binding for node.js for detecting content types by data inspection",
   "main": "./lib/index",
   "dependencies": {
-    "nan": "^2.2.1"
+    "nan": "^2.3.3"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
In Node 6.x, the following error might appear when an older version of nan is being used::

> (node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
>(node) and will stop working in the next major release.

This issue has already been [addressed](https://github.com/nodejs/nan/commit/a90951e9ea70fa1b3836af4b925322919159100e) in nan@2.3.1.
