### PR TITLE
Referencing directly to `.node` file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var path = require('path');
 
-var Magic = require('../build/Release/magic');
+var Magic = require('../build/Release/magic.node');
 
 var fbpath = path.join(__dirname, '..', 'magic', 'magic');
 Magic.setFallback(fbpath);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -271,7 +271,7 @@ public:
           free(baton->error_message);
 
         Local<Value> argv[1] = { err };
-        baton->callback->Call(1, argv);
+        node::MakeCallback(Context::GetCurrent()->Global(), baton->callback->GetFunction(), 1, argv);
       } else {
         Local<Value> argv[2];
         int multi_result_flags = (baton->flags & (MAGIC_CONTINUE | MAGIC_RAW));
@@ -318,7 +318,7 @@ public:
         if (baton->result)
           free((void*)baton->result);
 
-        baton->callback->Call(2, argv);
+        node::MakeCallback(Context::GetCurrent()->Global(), baton->callback->GetFunction(), 2, argv);
       }
 
       if (baton->dataIsPath)


### PR DESCRIPTION
Referencing directly to `.node` file for frameworks that are using implementations of require that do not search for `.node` files.