### PR TITLE
Added an option to compile a database file using mmmagic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dummy_magic_file.mgc
+dummy_magic_file2.mgc
+node_modules/
+build/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ Examples
   });
 ```
 
+* Compile a magic file:
+```javascript
+  var Magic = require('mmmagic').Magic;
+
+  var magic = new Magic();
+  
+  magic.compile("node_modules/mmmagic/test/dummy_magic_file", function(err, result) {
+      if (err) throw err;
+      console.log("Compiled magic file successfully. Compile file name: ", result);
+      // output: Compiled magic file successfully. Compile file name: [ 'dummy_magic_file.mgc' ]
+  });
+```
+
 API
 ===
 
@@ -108,3 +121,5 @@ Magic methods
 * **detectFile**(< _String_ >path, < _Function_ >callback) - _(void)_ - Inspects the file pointed at by path. The callback receives two arguments: an < _Error_ > object in case of error (null otherwise), and a < _String_ > containing the result of the inspection.
 
 * **detect**(< _Buffer_ >data, < _Function_ >callback) - _(void)_ - Inspects the contents of data. The callback receives two arguments: an < _Error_ > object in case of error (null otherwise), and a < _String_ > containing the result of the inspection.
+
+* **compile**(< _String_ >path, < _Function_ >callback) - _(void)_ - Compile a colon separated list of database files. The compiled files can be used later on with one of the other methods. The callback receives two arguments: an < _Error_ > object in case of error (null otherwise), and an array of < _String_ > containing the names of the compiled files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 { "name": "mmmagic",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": "Brian White <mscdex@mscdex.net>",
+  "contributors": "Roee Kasher <roee91@gmail.com>",
   "description": "An async libmagic binding for node.js for detecting content types by data inspection",
   "main": "./lib/index",
   "dependencies": {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -342,14 +342,148 @@ public:
       return args.GetReturnValue().Set(args.This());
     }
 
-    static void Initialize(Handle<Object> target) {
+    static void Compile(const Nan::FunctionCallbackInfo<v8::Value>& args) {
+      Nan::HandleScope();
+      Magic* obj = ObjectWrap::Unwrap<Magic>(args.This());
 
+      if (args.Length() < 2)
+        return Nan::ThrowTypeError("Expecting 2 arguments");
+      if (!args[0]->IsString())
+        return Nan::ThrowTypeError("First argument must be a string");
+      if (!args[1]->IsFunction())
+        return Nan::ThrowTypeError("Second argument must be a callback function");
+
+      Local<Function> callback = Local<Function>::Cast(args[1]);
+      String::Utf8Value str(args[0]->ToString());
+
+      Baton* baton = new Baton();
+      baton->error = false;
+      baton->free_error = true;
+      baton->error_message = NULL;
+      baton->request.data = baton;
+      baton->callback = new Nan::Callback(callback);
+      baton->data = strdup((const char*)*str);
+      baton->path = obj->mpath;
+      baton->result = NULL;
+
+      int status = uv_queue_work(uv_default_loop(),
+                                 &baton->request,
+                                 Magic::CompileWork,
+                                 (uv_after_work_cb)Magic::CompileAfter);
+      assert(status == 0);
+
+      args.GetReturnValue().Set(Nan::Undefined());
+    }
+
+    static void CompileWork(uv_work_t* req) {
+      Baton* baton = static_cast<Baton*>(req->data);
+      struct magic_set *magic = magic_open(baton->flags
+                                           | MAGIC_NO_CHECK_COMPRESS
+                                           | MAGIC_ERROR);
+
+      if (magic == NULL) {
+        baton->error = true;
+#if NODE_MODULE_VERSION <= 0x000B
+        baton->error_message = strdup(uv_strerror(
+                                        uv_last_error(uv_default_loop())));
+#else
+// XXX libuv 1.x currently has no public cross-platform function to convert an
+//     OS-specific error number to a libuv error number. `-errno` should work
+//     for *nix, but just passing GetLastError() on Windows will not work ...
+# ifdef _MSC_VER
+        baton->error_message = strdup(uv_strerror(GetLastError()));
+# else
+        baton->error_message = strdup(uv_strerror(-errno));
+# endif
+#endif
+        return;
+      }
+
+      int compile_result = magic_compile(magic, baton->data);
+
+      // Compile returns -1 if failed, and 0 if succeeded
+      if (compile_result == -1) {
+        const char* error = magic_error(magic);
+        if (error) {
+          baton->error = true;
+          baton->error_message = strdup(error);
+        }
+      }
+
+      magic_close(magic);
+    }
+
+    static void CompileAfter(uv_work_t* req) {
+      Nan::HandleScope scope;
+      Baton* baton = static_cast<Baton*>(req->data);
+
+      if (baton->error) {
+        // In case of error - return it to the user.
+        Local<Value> err = Nan::Error(baton->error_message);
+
+        if (baton->free_error)
+          free(baton->error_message);
+
+        Local<Value> argv[1] = { err };
+        baton->callback->Call(1, argv);
+      } else {
+        Local<Value> argv[2];
+        // no Error
+        argv[0] = Nan::Null();
+      
+        // Creating the list of the compiled magic files
+        Local<Array> results = Nan::New<Array>();
+        uint32_t i = 0;
+        char *file_path = strtok(baton->data, ":");
+
+        while(file_path != NULL)
+        {
+            // Getting the file name from the source
+            const char* file_path_dup = strdup(file_path);
+            const char* file_name = basename(file_path_dup);
+
+            // Creating the name of the mgc file (which is the magic file name + ".mgc")
+            size_t file_name_length = strlen(file_name);
+            size_t mgc_file_name_length = file_name_length + 4;
+            char* mgc_file_name = new char[mgc_file_name_length + 1];
+            strcpy(mgc_file_name, file_name);
+            strcat(mgc_file_name, ".mgc");
+            mgc_file_name[mgc_file_name_length] = '\0';
+
+            // Adding to results
+            Nan::Set(Local<Object>::Cast(results),
+                           i++,
+                           Nan::New<String>(mgc_file_name).ToLocalChecked());
+
+            // Cleaning
+            free((void*)file_path_dup);
+            delete[] mgc_file_name;
+
+            // Looking for the next file name
+            file_path=strtok(NULL, ":");
+        }
+
+        argv[1] = Local<Value>(results);
+
+        if (baton->result)
+          free((void*)baton->result);
+
+        baton->callback->Call(2, argv);
+      }
+
+      free(baton->data);
+      delete baton->callback;
+      delete baton;
+    }
+
+    static void Initialize(Handle<Object> target) {
       Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
 
       tpl->InstanceTemplate()->SetInternalFieldCount(1);
       tpl->SetClassName(Nan::New<String>("Magic").ToLocalChecked());
       Nan::SetPrototypeMethod(tpl, "detectFile", DetectFile);
       Nan::SetPrototypeMethod(tpl, "detect", Detect);
+      Nan::SetPrototypeMethod(tpl, "compile", Compile);
 
       constructor.Reset(tpl->GetFunction());
       target->Set(Nan::New<String>("setFallback").ToLocalChecked(),

--- a/test/dummy_magic_file
+++ b/test/dummy_magic_file
@@ -1,0 +1,3 @@
+0	belong&0xFF5FFF10	0x47400010
+>188	byte			0x47		MPEG transport stream data
+!:mimevideo/MP2T

--- a/test/dummy_magic_file2
+++ b/test/dummy_magic_file2
@@ -1,0 +1,3 @@
+0	belong&0xFF5FFF10	0x47400010
+>188	byte			0x47		MPEG transport stream data
+!:mimevideo/MP2T

--- a/test/test.js
+++ b/test/test.js
@@ -98,6 +98,30 @@ var tests = [
     },
     what: 'detect - Normal operation, mime type'
   },
+  { run: function() {
+      var dummy_magic_file = path.join(__dirname, 'dummy_magic_file');
+      var magic = new mmm.Magic();
+      magic.compile(dummy_magic_file, function(err, result) {
+        assert.strictEqual(err, null);
+        assert.deepEqual(result, ['dummy_magic_file' + '.mgc']);
+        next();
+      });
+    },
+    what: 'compile - one file'
+  }, 
+  { run: function() {
+      var dummy_magic_file = path.join(__dirname, 'dummy_magic_file');
+      var dummy_magic_file2 = dummy_magic_file + "2";
+      var colon_seperated_magic_files = dummy_magic_file + ":" + dummy_magic_file2;
+      var magic = new mmm.Magic(mmm.MAGIC_MIME_TYPE);
+      magic.compile(colon_seperated_magic_files, function(err, result) {
+        assert.strictEqual(err, null);
+        assert.deepEqual(result, ['dummy_magic_file' + '.mgc', 'dummy_magic_file2' + '.mgc']);
+        next();
+      });
+    },
+    what: 'compile - several files'
+  }
 ];
 
 function next() {


### PR DESCRIPTION
Added an option to compile a database file using `mmmagic`. This is extremely useful if the installed version of `libmagic` differs from the one used by `mmmagic`. The compiled magic files can be later used with the `detect` or `detectFile` methods.

Compiling is useful for extending `libmagic`'s detection - in case the default magic file fails to detect a file, a database file can be created in order to extend the `libmagic`'s detection.