### PR TITLE
Fix build on macOs Mojave with Xcode 10

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,16 @@
       'dependencies': [
         'deps/libmagic/libmagic.gyp:libmagic',
       ],
+      'conditions': [
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+            'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+            'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++1y',  # -std=gnu++1y
+            'CLANG_CXX_LIBRARY': 'libc++',
+          }
+        }],
+      ],
     },
   ],
 }


### PR DESCRIPTION
This fixes build issue with Xcode where it couldn't find C++ include files:

```
CXX(target) Release/obj.target/magic/src/binding.o
warning: include path for stdlibc++ headers not found; pass '-std=libc++' on the command line to use
      the libc++ standard library instead [-Wstdlibcxx-not-found]
In file included from ../src/binding.cc:3:
../node_modules/nan/nan.h:55:10: fatal error: 'algorithm' file not found
#include <algorithm>
         ^~~~~~~~~~~
1 warning and 1 error generated.
make: *** [Release/obj.target/magic/src/binding.o] Error 1
```