### PR TITLE
build: fix build on macOS Ventura | gnu 2020 [-Wc++17-extensions]

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,9 +21,9 @@
       'conditions': [
         ['OS=="mac"', {
           'xcode_settings': {
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+            'MACOSX_DEPLOYMENT_TARGET': '13.4',
             'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-            'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++1y',  # -std=gnu++1y
+            'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++20',  # -std=gnu++1y | 1y is gnu++14 but we can safely update to 2020 version
             'CLANG_CXX_LIBRARY': 'libc++',
           }
         }],


### PR DESCRIPTION
Since the node update from v18 to v19 mmmagic didn't compile anymore because missing C++ extensions. This merge request fixes that by changing the compiler and target platform.

Warning that it used to throw:
```
'static_assert' with no message is a C++17 extension [-Wc++17-extensions]
```

Error that is threw:
```
error: expected '(' for function-style cast or type construction
```

Please take a look and accept the merge request if you are happy with it.
Thanks in advance!

PS: I have not tested or it works on Mac if you OS is not up to date. 
