### PR TITLE
fixed compiling issue with msvc

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -281,8 +281,11 @@ public:
         }
         if (fd == -1) {
           detect_req->free_error = false;
-          detect_req->error_message = "Error while opening file";
-          magic_close(magic);
+					const char *error_msg = "Error while opening file";
+					char* copy = static_cast<char*>(malloc(strlen(error_msg) + 1));
+					strcpy(copy, error_msg);
+					detect_req->error_message = copy;
+					magic_close(magic);
           return;
         }
         result = magic_descriptor(magic, fd);


### PR DESCRIPTION
```
│ C:\Users\moopi\Desktop\privatise-cf\node_modules\.pnpm\mmmagic@0.5.3\node_modules\mmmagic\src\binding.cc(284,39): error C2440: '=': cannot convert from 'const char [25]' to 'char *' [C:\Users\moopi…  
│       C:\Users\moopi\Desktop\privatise-cf\node_modules\.pnpm\mmmagic@0.5.3\node_modules\mmmagic\src\binding.cc(284,39):
│       Conversion from string literal loses const qualifier (see /Zc:strictStrings)
│
│ gyp ERR! build error
│ gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
│ gyp ERR! stack at ChildProcess.<anonymous> (C:\Users\moopi\scoop\persist\nodejs\bin\node_modules\pnpm\dist\node_modules\node-gyp\lib\build.js:216:23)
│ gyp ERR! stack at ChildProcess.emit (node:events:507:28)
│ gyp ERR! stack at ChildProcess._handle.onexit (node:internal/child_process:294:12)
│ gyp ERR! System Windows_NT 10.0.26100
│ gyp ERR! command "C:\\Users\\moopi\\scoop\\apps\\nodejs\\current\\node.exe" "C:\\Users\\moopi\\scoop\\persist\\nodejs\\bin\\node_modules\\pnpm\\dist\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebu…  
│ gyp ERR! cwd C:\Users\moopi\Desktop\privatise-cf\node_modules\.pnpm\mmmagic@0.5.3\node_modules\mmmagic
│ gyp ERR! node -v v23.10.0
│ gyp ERR! node-gyp -v v11.1.0
│ gyp ERR! not ok
└─ Failed in 16.6s at C:\Users\moopi\Desktop\privatise-cf\node_modules\.pnpm\mmmagic@0.5.3\node_modules\mmmagic
 ELIFECYCLE  Command failed with exit code 1.
```  
lol